### PR TITLE
Feat: Autopopulate company ID in role management

### DIFF
--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -389,6 +389,17 @@ export function RoleManagement() {
                   }
                 />
               </div>
+
+              <div>
+                <Label htmlFor="company_id">Company ID</Label>
+                <Input
+                  id="company_id"
+                  placeholder="Company ID"
+                  value={formData.company_id}
+                  onChange={() => {}}
+                  disabled
+                />
+              </div>
             </div>
 
             <div>

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -93,6 +93,7 @@ export function RoleManagement() {
     name: '',
     description: '',
     permissions: [] as Permission[],
+    company_id: profile?.company_id || '',
   });
 
   if (!isAdmin) {

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -128,7 +128,7 @@ export function RoleManagement() {
 
       if (result.success) {
         setCreateDialogOpen(false);
-        setFormData({ name: '', description: '', permissions: [] });
+        setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
       } else {
         toast.error(result.error || 'Failed to create role');
       }

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -464,7 +464,7 @@ export function RoleManagement() {
                 setCreateDialogOpen(false);
                 setEditDialogOpen(false);
                 setEditingRole(null);
-                setFormData({ name: '', description: '', permissions: [] });
+                setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
               }}
               disabled={submitting}
             >

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -52,6 +52,7 @@ import {
 } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAuth } from '@/contexts/AuthContext';
+import { useCurrentCompanyId } from '@/contexts/CompanyContext';
 import useRoleManagement from '@/hooks/useRoleManagement';
 import { Permission, PERMISSION_DESCRIPTIONS, RoleDefinition } from '@/types/permissions';
 import { toast } from 'sonner';

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -342,7 +342,7 @@ export function RoleManagement() {
             setCreateDialogOpen(false);
             setEditDialogOpen(false);
             setEditingRole(null);
-            setFormData({ name: '', description: '', permissions: [] });
+            setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
           }
         }}
       >

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -226,7 +226,7 @@ export function RoleManagement() {
           size="lg"
           onClick={() => {
             setEditingRole(null);
-            setFormData({ name: '', description: '', permissions: [] });
+            setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
             setCreateDialogOpen(true);
           }}
         >

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -157,7 +157,7 @@ export function RoleManagement() {
       if (result.success) {
         setEditDialogOpen(false);
         setEditingRole(null);
-        setFormData({ name: '', description: '', permissions: [] });
+        setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
       } else {
         toast.error(result.error || 'Failed to update role');
       }

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -128,6 +128,8 @@ export function RoleManagement() {
       if (result.success) {
         setCreateDialogOpen(false);
         setFormData({ name: '', description: '', permissions: [] });
+      } else {
+        toast.error(result.error || 'Failed to create role');
       }
     } catch (error) {
       console.error('Error creating role:', error);
@@ -155,6 +157,8 @@ export function RoleManagement() {
         setEditDialogOpen(false);
         setEditingRole(null);
         setFormData({ name: '', description: '', permissions: [] });
+      } else {
+        toast.error(result.error || 'Failed to update role');
       }
     } catch (error) {
       console.error('Error updating role:', error);

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -131,7 +131,7 @@ export function RoleManagement() {
 
       if (result.success) {
         setCreateDialogOpen(false);
-        setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
+        setFormData({ name: '', description: '', permissions: [], company_id: currentCompanyId || profile?.company_id || '' });
       } else {
         toast.error(result.error || 'Failed to create role');
       }
@@ -160,7 +160,7 @@ export function RoleManagement() {
       if (result.success) {
         setEditDialogOpen(false);
         setEditingRole(null);
-        setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
+        setFormData({ name: '', description: '', permissions: [], company_id: currentCompanyId || profile?.company_id || '' });
       } else {
         toast.error(result.error || 'Failed to update role');
       }
@@ -230,7 +230,7 @@ export function RoleManagement() {
           size="lg"
           onClick={() => {
             setEditingRole(null);
-            setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
+            setFormData({ name: '', description: '', permissions: [], company_id: currentCompanyId || profile?.company_id || '' });
             setCreateDialogOpen(true);
           }}
         >
@@ -346,7 +346,7 @@ export function RoleManagement() {
             setCreateDialogOpen(false);
             setEditDialogOpen(false);
             setEditingRole(null);
-            setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
+            setFormData({ name: '', description: '', permissions: [], company_id: currentCompanyId || profile?.company_id || '' });
           }
         }}
       >
@@ -478,7 +478,7 @@ export function RoleManagement() {
                 setCreateDialogOpen(false);
                 setEditDialogOpen(false);
                 setEditingRole(null);
-                setFormData({ name: '', description: '', permissions: [], company_id: profile?.company_id || '' });
+                setFormData({ name: '', description: '', permissions: [], company_id: currentCompanyId || profile?.company_id || '' });
               }}
               disabled={submitting}
             >

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -124,6 +124,7 @@ export function RoleManagement() {
         name: formData.name,
         description: formData.description,
         permissions: formData.permissions,
+        company_id: formData.company_id,
       });
 
       if (result.success) {

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -78,6 +78,7 @@ const PERMISSION_GROUPS: Record<string, Permission[]> = {
 
 export function RoleManagement() {
   const { isAdmin, profile } = useAuth();
+  const currentCompanyId = useCurrentCompanyId();
   const { roles, loading, createRole, updateRole, deleteRole } = useRoleManagement();
 
   const [searchTerm, setSearchTerm] = useState('');

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -186,6 +186,7 @@ export function RoleManagement() {
       name: role.name,
       description: role.description || '',
       permissions: role.permissions,
+      company_id: (role as any).company_id || profile?.company_id || '',
     });
     setEditDialogOpen(true);
   };

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -189,7 +189,7 @@ export function RoleManagement() {
       name: role.name,
       description: role.description || '',
       permissions: role.permissions,
-      company_id: (role as any).company_id || profile?.company_id || '',
+      company_id: (role as any).company_id || currentCompanyId || profile?.company_id || '',
     });
     setEditDialogOpen(true);
   };

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -95,7 +95,7 @@ export function RoleManagement() {
     name: '',
     description: '',
     permissions: [] as Permission[],
-    company_id: profile?.company_id || '',
+    company_id: currentCompanyId || profile?.company_id || '',
   });
 
   if (!isAdmin) {

--- a/src/components/settings/RoleManagement.tsx
+++ b/src/components/settings/RoleManagement.tsx
@@ -76,7 +76,7 @@ const PERMISSION_GROUPS: Record<string, Permission[]> = {
 };
 
 export function RoleManagement() {
-  const { isAdmin } = useAuth();
+  const { isAdmin, profile } = useAuth();
   const { roles, loading, createRole, updateRole, deleteRole } = useRoleManagement();
 
   const [searchTerm, setSearchTerm] = useState('');

--- a/src/hooks/useRoleManagement.ts
+++ b/src/hooks/useRoleManagement.ts
@@ -10,6 +10,7 @@ interface CreateRoleData {
   name: string;
   description?: string;
   permissions: Permission[];
+  company_id?: string;
 }
 
 interface UpdateRoleData {
@@ -70,13 +71,14 @@ export const useRoleManagement = () => {
     setLoading(true);
 
     try {
+      const companyIdToUse = data.company_id || currentUser.company_id;
       const { data: newRole, error: createError } = await supabase
         .from('roles')
         .insert({
           name: data.name,
           description: data.description,
           permissions: data.permissions,
-          company_id: currentUser.company_id,
+          company_id: companyIdToUse,
           role_type: 'custom',
           is_default: false,
         })
@@ -89,7 +91,7 @@ export const useRoleManagement = () => {
 
       // Log the role creation
       try {
-        await logRoleChange('create', newRole.id, data.name, currentUser.company_id, {
+        await logRoleChange('create', newRole.id, data.name, companyIdToUse, {
           permissions: data.permissions,
         });
       } catch (auditError) {

--- a/src/hooks/useRoleManagement.ts
+++ b/src/hooks/useRoleManagement.ts
@@ -63,6 +63,7 @@ export const useRoleManagement = () => {
    */
   const createRole = async (data: CreateRoleData): Promise<{ success: boolean; role?: RoleDefinition; error?: string }> => {
     if (!isAdmin || !currentUser?.company_id) {
+      toast.error('You are not authorized or no company is selected');
       return { success: false, error: 'Unauthorized' };
     }
 
@@ -116,6 +117,7 @@ export const useRoleManagement = () => {
     data: UpdateRoleData
   ): Promise<{ success: boolean; error?: string }> => {
     if (!isAdmin) {
+      toast.error('You are not authorized to update roles');
       return { success: false, error: 'Unauthorized' };
     }
 
@@ -184,6 +186,7 @@ export const useRoleManagement = () => {
    */
   const deleteRole = async (roleId: string): Promise<{ success: boolean; error?: string }> => {
     if (!isAdmin) {
+      toast.error('You are not authorized to delete roles');
       return { success: false, error: 'Unauthorized' };
     }
 


### PR DESCRIPTION
### Purpose

The user wants to streamline the role creation process by automatically associating the current user's company ID with any new or updated roles. This avoids the need for manual entry and prevents errors where the company ID is missing, as seen in the conversation history.

### Code changes

- **`src/components/settings/RoleManagement.tsx`**
  - Fetches the `currentCompanyId` to automatically populate the company ID when creating or editing a role.
  - A disabled "Company ID" input field has been added to the form to show the user which company the role is being created for.
  - Ensures the `company_id` is included when calling `createRole` and `updateRole`.

- **`src/hooks/useRoleManagement.ts`**
  - The `createRole` function now accepts a `company_id` in its data payload.
  - If a `company_id` is provided, it is used; otherwise, it defaults to the logged-in user's company ID.
  - Added more specific error toasts for unauthorized actions to improve user feedback.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9f54f558bef049b2940c12f5093683ef/glow-hub)

👀 [Preview Link](https://9f54f558bef049b2940c12f5093683ef-glow-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9f54f558bef049b2940c12f5093683ef</projectId>-->
<!--<branchName>glow-hub</branchName>-->