### PR TITLE
feat: Update customer payment term options

### DIFF
--- a/src/components/customers/CreateCustomerModal.tsx
+++ b/src/components/customers/CreateCustomerModal.tsx
@@ -134,7 +134,7 @@ export function CreateCustomerModal({ open, onOpenChange, onSuccess }: CreateCus
       city: '',
       country: 'Kenya',
       credit_limit: 100000,
-      payment_terms: 30,
+      payment_terms: 0,
       is_active: true,
     });
     onOpenChange(false);

--- a/src/components/customers/CreateCustomerModal.tsx
+++ b/src/components/customers/CreateCustomerModal.tsx
@@ -47,7 +47,7 @@ export function CreateCustomerModal({ open, onOpenChange, onSuccess }: CreateCus
     city: '',
     country: 'Kenya',
     credit_limit: 100000,
-    payment_terms: 30,
+    payment_terms: 0,
     is_active: true,
   });
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/src/components/customers/CreateCustomerModal.tsx
+++ b/src/components/customers/CreateCustomerModal.tsx
@@ -310,7 +310,7 @@ export function CreateCustomerModal({ open, onOpenChange, onSuccess }: CreateCus
                 <div className="space-y-1 text-sm text-muted-foreground">
                   <p>Code: {generateCustomerCode()}</p>
                   <p>Credit Limit: KES {formData.credit_limit.toLocaleString()}</p>
-                  <p>Payment Terms: {formData.payment_terms} days</p>
+                  <p>Payment Terms: {formData.payment_terms === 0 ? 'Cash (Now)' : `${formData.payment_terms} days`}</p>
                   <p>Status: {formData.is_active ? 'Active' : 'Inactive'}</p>
                 </div>
               </div>

--- a/src/components/customers/CreateCustomerModal.tsx
+++ b/src/components/customers/CreateCustomerModal.tsx
@@ -98,7 +98,7 @@ export function CreateCustomerModal({ open, onOpenChange, onSuccess }: CreateCus
         city: '',
         country: 'Kenya',
         credit_limit: 100000,
-        payment_terms: 30,
+        payment_terms: 0,
         is_active: true,
       });
     } catch (error: any) {

--- a/src/components/customers/CreateCustomerModal.tsx
+++ b/src/components/customers/CreateCustomerModal.tsx
@@ -273,19 +273,20 @@ export function CreateCustomerModal({ open, onOpenChange, onSuccess }: CreateCus
 
               <div className="space-y-2">
                 <Label htmlFor="payment_terms">Payment Terms (Days)</Label>
-                <Select 
-                  value={formData.payment_terms.toString()} 
+                <Select
+                  value={formData.payment_terms.toString()}
                   onValueChange={(value) => handleInputChange('payment_terms', parseInt(value))}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Select payment terms" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="7">7 days</SelectItem>
+                    <SelectItem value="0">Cash (Now)</SelectItem>
                     <SelectItem value="14">14 days</SelectItem>
-                    <SelectItem value="30">30 days</SelectItem>
+                    <SelectItem value="45">45 days</SelectItem>
                     <SelectItem value="60">60 days</SelectItem>
-                    <SelectItem value="90">90 days</SelectItem>
+                    <SelectItem value="120">120 days</SelectItem>
+                    <SelectItem value="180">Up to 180 days</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/src/components/customers/EditCustomerModal.tsx
+++ b/src/components/customers/EditCustomerModal.tsx
@@ -61,7 +61,7 @@ export function EditCustomerModal({ open, onOpenChange, onSuccess, customer }: E
     city: '',
     country: 'Kenya',
     credit_limit: 0,
-    payment_terms: 30,
+    payment_terms: 0,
     is_active: true,
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -78,7 +78,7 @@ export function EditCustomerModal({ open, onOpenChange, onSuccess, customer }: E
         city: customer.city || '',
         country: customer.country || 'Kenya',
         credit_limit: customer.credit_limit || 0,
-        payment_terms: customer.payment_terms || 30,
+        payment_terms: customer.payment_terms || 0,
         is_active: customer.is_active !== false,
       });
     }
@@ -253,19 +253,20 @@ export function EditCustomerModal({ open, onOpenChange, onSuccess, customer }: E
 
               <div className="space-y-2">
                 <Label htmlFor="payment_terms">Payment Terms (Days)</Label>
-                <Select 
-                  value={formData.payment_terms.toString()} 
+                <Select
+                  value={formData.payment_terms.toString()}
                   onValueChange={(value) => handleInputChange('payment_terms', parseInt(value))}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Select payment terms" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="7">7 days</SelectItem>
+                    <SelectItem value="0">Cash (Now)</SelectItem>
                     <SelectItem value="14">14 days</SelectItem>
-                    <SelectItem value="30">30 days</SelectItem>
+                    <SelectItem value="45">45 days</SelectItem>
                     <SelectItem value="60">60 days</SelectItem>
-                    <SelectItem value="90">90 days</SelectItem>
+                    <SelectItem value="120">120 days</SelectItem>
+                    <SelectItem value="180">Up to 180 days</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -289,7 +290,7 @@ export function EditCustomerModal({ open, onOpenChange, onSuccess, customer }: E
                 <div className="space-y-1 text-sm text-muted-foreground">
                   <p>Code: {customer?.customer_code}</p>
                   <p>Credit Limit: KES {formData.credit_limit.toLocaleString()}</p>
-                  <p>Payment Terms: {formData.payment_terms} days</p>
+                  <p>Payment Terms: {formData.payment_terms === 0 ? 'Cash (Now)' : `${formData.payment_terms} days`}</p>
                   <p>Status: {formData.is_active ? 'Active' : 'Inactive'}</p>
                 </div>
               </div>

--- a/src/components/customers/ViewCustomerModal.tsx
+++ b/src/components/customers/ViewCustomerModal.tsx
@@ -181,7 +181,7 @@ export function ViewCustomerModal({ open, onOpenChange, customer, onEdit, onCrea
               <div className="flex items-center space-x-3">
                 <Calendar className="h-4 w-4 text-muted-foreground" />
                 <div>
-                  <div className="font-medium">{customer.payment_terms || 30} days</div>
+                  <div className="font-medium">{customer.payment_terms === 0 ? 'Cash (Now)' : `${customer.payment_terms || 0} days`}</div>
                   <div className="text-sm text-muted-foreground">Payment Terms</div>
                 </div>
               </div>

--- a/src/pages/Customers.tsx
+++ b/src/pages/Customers.tsx
@@ -465,7 +465,7 @@ export default function Customers() {
                       {formatCurrency(customer.credit_limit || 0)}
                     </TableCell>
                     <TableCell className="hidden md:table-cell">
-                      {customer.payment_terms || 30} days
+                      {customer.payment_terms === 0 ? 'Cash (Now)' : `${customer.payment_terms || 0} days`}
                     </TableCell>
                     <TableCell>
                       <Badge variant="outline" className={getStatusColor(customer.is_active !== false)}>

--- a/src/pages/OptimizedCustomers.tsx
+++ b/src/pages/OptimizedCustomers.tsx
@@ -113,7 +113,7 @@ const CustomerRow = React.memo(({
         {customer.credit_limit ? formatter.format(customer.credit_limit) : 'No limit'}
       </TableCell>
       <TableCell className="hidden md:table-cell">
-        {customer.payment_terms || 30} days
+        {customer.payment_terms === 0 ? 'Cash (Now)' : `${customer.payment_terms || 0} days`}
       </TableCell>
       <TableCell>
         <Badge variant="outline" className={getCustomerStatusColor(isActive)}>


### PR DESCRIPTION
### Purpose

Based on the user's request, this change updates the payment term options for customers. The goal is to replace the existing payment day options with a new set, including a "Cash (Now)" option as the default.

### Code changes

- **Default Payment Terms:** The default value for `payment_terms` has been changed from `30` to `0` in `CreateCustomerModal.tsx` and `EditCustomerModal.tsx` to reflect the new "Cash (Now)" default.
- **Updated Select Options:** The payment term dropdown in `CreateCustomerModal.tsx` and `EditCustomerModal.tsx` has been updated to include the new options: "Cash (Now)", "14 days", "45 days", "60 days", "120 days", and "Up to 180 days".
- **Display Logic:** Updated the UI in `CreateCustomerModal.tsx`, `EditCustomerModal.tsx`, `ViewCustomerModal.tsx`, `Customers.tsx`, and `OptimizedCustomers.tsx` to display "Cash (Now)" when the payment term is `0`, and "N days" otherwise, ensuring consistent representation across the application.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`

🔗 [Edit in Builder.io](https://builder.io/app/projects/34fa2c49711b4818aad8e50aa3a28b1b/neon-nest)

👀 [Preview Link](https://34fa2c49711b4818aad8e50aa3a28b1b-neon-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>34fa2c49711b4818aad8e50aa3a28b1b</projectId>-->
<!--<branchName>neon-nest</branchName>-->