### PR TITLE
fix: Add missing values to document_status enum

### DIFF
--- a/COMPREHENSIVE_DATABASE_MIGRATION.sql
+++ b/COMPREHENSIVE_DATABASE_MIGRATION.sql
@@ -33,7 +33,7 @@ END $$;
 
 -- Document status enumeration
 DO $$ BEGIN
-    CREATE TYPE document_status AS ENUM ('draft', 'pending', 'approved', 'sent', 'paid', 'partial', 'overdue', 'cancelled', 'expired', 'accepted', 'rejected');
+    CREATE TYPE document_status AS ENUM ('draft', 'pending', 'approved', 'sent', 'paid', 'partial', 'overdue', 'cancelled', 'expired', 'accepted', 'rejected', 'converted');
 EXCEPTION
     WHEN duplicate_object THEN null;
 END $$;

--- a/database-schema.sql
+++ b/database-schema.sql
@@ -103,7 +103,7 @@ CREATE TABLE products (
 );
 
 -- Document status enum
-CREATE TYPE document_status AS ENUM ('draft', 'pending', 'approved', 'sent', 'paid', 'cancelled', 'overdue');
+CREATE TYPE document_status AS ENUM ('draft', 'pending', 'approved', 'sent', 'paid', 'partial', 'cancelled', 'overdue', 'accepted', 'expired', 'converted', 'rejected');
 
 -- Document types enum
 CREATE TYPE document_type AS ENUM ('quotation', 'invoice', 'proforma', 'delivery_note', 'credit_note', 'debit_note');

--- a/supabase/migrations/20250128_add_proforma_status_values.sql
+++ b/supabase/migrations/20250128_add_proforma_status_values.sql
@@ -1,0 +1,55 @@
+-- Migration: Add missing status values to document_status enum
+-- Purpose: Fix "invalid input value for" error when changing proforma status
+-- These values are used by the app but were missing from the enum:
+--   - 'accepted' (proforma accepted by customer)
+--   - 'expired' (proforma validity expired)
+--   - 'converted' (proforma converted to invoice)
+
+DO $$
+BEGIN
+  -- Add 'accepted' if it doesn't exist
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum e
+    JOIN pg_type t ON e.enumtypid = t.oid
+    WHERE t.typname = 'document_status' AND e.enumlabel = 'accepted'
+  ) THEN
+    ALTER TYPE document_status ADD VALUE 'accepted';
+  END IF;
+
+  -- Add 'expired' if it doesn't exist
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum e
+    JOIN pg_type t ON e.enumtypid = t.oid
+    WHERE t.typname = 'document_status' AND e.enumlabel = 'expired'
+  ) THEN
+    ALTER TYPE document_status ADD VALUE 'expired';
+  END IF;
+
+  -- Add 'converted' if it doesn't exist
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum e
+    JOIN pg_type t ON e.enumtypid = t.oid
+    WHERE t.typname = 'document_status' AND e.enumlabel = 'converted'
+  ) THEN
+    ALTER TYPE document_status ADD VALUE 'converted';
+  END IF;
+
+  -- Add 'rejected' if it doesn't exist (for quotations/proforma rejection)
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum e
+    JOIN pg_type t ON e.enumtypid = t.oid
+    WHERE t.typname = 'document_status' AND e.enumlabel = 'rejected'
+  ) THEN
+    ALTER TYPE document_status ADD VALUE 'rejected';
+  END IF;
+
+  -- Add 'partial' if it doesn't exist (for partial payments)
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum e
+    JOIN pg_type t ON e.enumtypid = t.oid
+    WHERE t.typname = 'document_status' AND e.enumlabel = 'partial'
+  ) THEN
+    ALTER TYPE document_status ADD VALUE 'partial' BEFORE 'paid';
+  END IF;
+
+END $$;


### PR DESCRIPTION
<!-- FUSION_KEEP_START -->
<i>This PR was created by Simon Gichu (gichukisimon99900@gmail.com)</i>
<!-- FUSION_KEEP_END -->


### Purpose

The user encountered an "invalid input value for" error when updating the status of a proforma document. This was due to several status values being used in the application logic but missing from the `document_status` enum in the database. This PR adds the missing values to fix the error.

### Code changes

- A new Supabase migration (`20250128_add_proforma_status_values.sql`) is introduced to safely add the new values to the `document_status` enum.
- The following status values are added: `accepted`, `expired`, `converted`, `rejected`, and `partial`.
- The `database-schema.sql` and `COMPREHENSIVE_DATABASE_MIGRATION.sql` files have been updated to align with the new enum definition.


To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1b21882718524607a08ee7789bb7ac12/curry-nest)

👀 [Preview Link](https://1b21882718524607a08ee7789bb7ac12-curry-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1b21882718524607a08ee7789bb7ac12</projectId>-->
<!--<branchName>curry-nest</branchName>-->